### PR TITLE
Add linux header to executable script

### DIFF
--- a/download_archive.sh
+++ b/download_archive.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 youtube-dl --config-location youtube-dl.conf


### PR DESCRIPTION
Hi there! 
I like your script. Exactly what I needed without reading tons of documentation. It's nice to learn that I can use a configuration file. 
By default on linux the script did not work because it was missing the header. So just fixed it for you and other people. 